### PR TITLE
fix: BiopythonDeprecationWarning

### DIFF
--- a/source/tg_align.py
+++ b/source/tg_align.py
@@ -70,7 +70,6 @@ def get_scoring_matrix(canon_char, which_type='tvr'):
 def get_aligner_object(scoring_matrix=None, gap_bool=(True,True), which_type='tvr'):
     aligner = PairwiseAligner()
     aligner.mode = 'global'
-    aligner.alphabet = ''.join(AMINO) + GAP_CHR
     if which_type == 'tvr':
         gap_open = -4.
         gap_extend = -4.


### PR DESCRIPTION
the following line generates this warning: 

/usr/share/miniconda/envs/test/lib/python3.10/site-packages/Bio/Align/__init__.py:4399: BiopythonDeprecationWarning: The alphabet property is deprecated. The current implementation stores the alphabet, but does not use it.

sounds like it should be safe to remove. 